### PR TITLE
Set ICE remote credentials when receiving remote SDP, instead of later

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -3107,12 +3107,6 @@ void janus_ice_setup_remote_candidates(janus_ice_handle *handle, guint stream_id
 		JANUS_LOG(LOG_VERB, "[%"SCNu64"]   Password:   %s\n", handle->handle_id, c->password);
 		gsc = gsc->next;
 	}
-	if(rufrag && rpwd) {
-		JANUS_LOG(LOG_VERB, "[%"SCNu64"]  Setting remote credentials...\n", handle->handle_id);
-		if(!nice_agent_set_remote_credentials(handle->agent, stream_id, rufrag, rpwd)) {
-			JANUS_LOG(LOG_ERR, "[%"SCNu64"]  failed to set remote credentials!\n", handle->handle_id);
-		}
-	}
 	guint added = nice_agent_set_remote_candidates(handle->agent, stream_id, component_id, component->candidates);
 	if(added < g_slist_length(component->candidates)) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to set remote candidates :-( (added %u, expected %u)\n",

--- a/sdp.c
+++ b/sdp.c
@@ -364,6 +364,13 @@ int janus_sdp_process(void *ice_handle, janus_sdp *remote_sdp, gboolean update) 
 				rfingerprint = NULL;
 				return -2;
 			}
+			/* If we received the ICE credentials for the first time, enforce them */
+			if(ruser && !stream->ruser && rpass && !stream->rpass) {
+				JANUS_LOG(LOG_VERB, "[%"SCNu64"] Setting remote credentials...\n", handle->handle_id);
+				if(!nice_agent_set_remote_credentials(handle->agent, handle->stream_id, ruser, rpass)) {
+					JANUS_LOG(LOG_ERR, "[%"SCNu64"] Failed to set remote credentials!\n", handle->handle_id);
+				}
+			} else
 			/* If this is a renegotiation, check if this is an ICE restart */
 			if((ruser && stream->ruser && strcmp(ruser, stream->ruser)) ||
 					(rpass && stream->rpass && strcmp(rpass, stream->rpass))) {


### PR DESCRIPTION
Merge in fix to handle empty remote ice candidates situation.
Update janus-gateway code to track Meetecho master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/janus-gateway/1)
<!-- Reviewable:end -->
