### PR TITLE
[CDN-457] Added Codefresh Build

### DIFF
--- a/caffeine/Dockerfile
+++ b/caffeine/Dockerfile
@@ -61,33 +61,3 @@ RUN cd ~ \
     && make shared_library \
     && make install
 
-# RUN mkdir janus-gateway
-# COPY . janus-gateway/
-# WORKDIR janus-gateway
-
-# # make Janus
-# RUN sh autogen.sh
-# RUN ./configure \
-#     --prefix=/opt/janus \
-#     --disable-data-channels \
-#     --disable-docs \
-#     --disable-mqtt \
-#     --disable-plugin-audiobridge \
-#     --disable-plugin-echotest \
-#     --disable-plugin-recordplay \
-#     --disable-plugin-sip \
-#     --disable-plugin-textroom \
-#     --disable-plugin-videocall \
-#     --disable-plugin-voicemail \
-#     --disable-post-processing \
-#     --disable-rabbitmq \
-#     --disable-turn-rest-api \
-#     --disable-sample-event-handler \
-#     --disable-websockets \
-#     --enable-unix-sockets \
-#     --enable-plugin-streaming \
-#     --enable-plugin-videoroom \
-#     --enable-rest \
-#     --enable-static
-
-# RUN make check install

--- a/caffeine/Dockerfile
+++ b/caffeine/Dockerfile
@@ -1,0 +1,93 @@
+# Dockerfile to build Janus container
+
+FROM ubuntu:16.04
+
+MAINTAINER ckousik@caffeine.tv
+
+RUN apt-get update && \
+	apt-get upgrade -y
+RUN apt-get install -y \
+    curl  \
+    git \
+    jq \
+    pkg-config \
+    software-properties-common \
+    make \
+    automake \
+    autoconf \
+    build-essential \
+    gengetopt \
+    libtool \
+    openssl \
+    gtk-doc-tools \
+    wget
+
+RUN apt-get install -y \
+    --no-install-recommends \
+    libglib2.0-dev \
+    libjansson-dev \
+    libmicrohttpd-dev \
+    libmicrohttpd10 \
+    libopus-dev \
+    libogg-dev \
+    libsofia-sip-ua-dev \
+    libssl-dev \
+    libwebsockets-dev \
+    libwebsockets7
+
+# libconfig
+RUN wget https://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz \
+    && tar xfv libconfig-1.7.2.tar.gz \
+    && rm -rf libconfig-1.7.2.tar.gz \
+    && cd libconfig-1.7.2 \
+    && ./configure \
+    --enable-static \
+    && make install
+
+RUN git clone https://gitlab.freedesktop.org/libnice/libnice.git \
+    && cd libnice \
+    && git checkout tags/0.1.16 \
+    && ./autogen.sh \
+    && ./configure \
+    --enable-static \
+    && make install
+
+# Install libsrtp
+RUN cd ~ \
+    && git clone https://github.com/cisco/libsrtp.git \
+    && cd libsrtp \
+    && git checkout v2.0.0 \
+    && ./configure --enable-openssl \
+    && make shared_library \
+    && make install
+
+# RUN mkdir janus-gateway
+# COPY . janus-gateway/
+# WORKDIR janus-gateway
+
+# # make Janus
+# RUN sh autogen.sh
+# RUN ./configure \
+#     --prefix=/opt/janus \
+#     --disable-data-channels \
+#     --disable-docs \
+#     --disable-mqtt \
+#     --disable-plugin-audiobridge \
+#     --disable-plugin-echotest \
+#     --disable-plugin-recordplay \
+#     --disable-plugin-sip \
+#     --disable-plugin-textroom \
+#     --disable-plugin-videocall \
+#     --disable-plugin-voicemail \
+#     --disable-post-processing \
+#     --disable-rabbitmq \
+#     --disable-turn-rest-api \
+#     --disable-sample-event-handler \
+#     --disable-websockets \
+#     --enable-unix-sockets \
+#     --enable-plugin-streaming \
+#     --enable-plugin-videoroom \
+#     --enable-rest \
+#     --enable-static
+
+# RUN make check install

--- a/caffeine/codefresh.build.yaml
+++ b/caffeine/codefresh.build.yaml
@@ -1,0 +1,139 @@
+version: '1.0'
+steps:
+  main_clone:
+    type: "git-clone"
+    description: "Cloning main repository..."
+    repo: "caffeinetv/janus-gateway"
+    revision: "${{CF_BRANCH}}"
+  BuildJanusBase:
+    type: build
+    title: Build Janus base image
+    description: "Build Janus base image"
+    image_name: caffeine/janus_base
+    tag: '${{CF_BRANCH_TAG_NORMALIZED}}'
+    dockerfile: caffeine/Dockerfile
+  BuildJanus:
+    title: Build Janus binaries
+    description: "Build Janus binaries in shared volume"
+    image: ${{BuildJanusBase}}
+    working_directory: ${{main_clone}}
+    commands:
+      - ./caffeine/scripts/codefresh-build.sh
+  plugin_clone:
+    type: "git-clone"
+    description: "Cloning plugin repository..."
+    working_directory: ~/janus-plugin-forwarder
+    repo: "caffeinetv/janus-plugin-forwarder"
+    revision: tags/stable
+  BuildJanusPlugin:
+    title: Build Janus Plugin
+    working_directory: ${{plugin_clone}}
+    image: ${{BuildJanusBase}}
+    commands:
+      - JANUSP=$CF_VOLUME_PATH/opt/janus make install
+  CreateArtifacts:
+    title: Create Artifacts
+    description: Create artifact archives
+    image: ${{BuildJanusBase}}
+    working_directory: /codefresh/volume
+    commands:
+      - |-
+        artifact=""
+        tar cvzf janus.tgz ./opt
+        # Just for verification
+        tar tzf janus.tgz
+        tag="$(date "+%Y%m%d-%H%M%S")-$CF_SHORT_REVISION"
+        echo tag=${tag} >> env_vars_to_export
+  UploadArtifacts:
+    type: parallel
+    steps:
+      UploadPr:
+        title: Upload PR binary archive
+        description: |-
+          Upload PR binary archive to S3
+        image: 'opsgang/awscli:stable'
+        environment:
+          - AWS_REGION=us-west-2
+        working_directory: /codefresh/volume
+        commands:
+          - |-
+            artifact=janus-pr${CF_PULL_REQUEST_NUMBER}-${tag}-b${CF_BUILD_ID}.tgz
+            aws s3api put-object \
+              --acl bucket-owner-full-control \
+              --body janus.tgz \
+              --bucket caffeine-salt \
+              --key cdn/files/janus-bin/$artifact
+        when:
+          steps:
+            - name: CreateArtifacts
+              on:
+                - success
+      UploadLatestPr:
+        title: Upload latest PR binary archive
+        description: |-
+          Upload master binary archive to S3
+        image: 'opsgang/awscli:stable'
+        environment:
+          - AWS_REGION=us-west-2
+        working_directory: /codefresh/volume
+        commands:
+          - |-
+            aws s3api put-object \
+              --acl bucket-owner-full-control \
+              --body janus.tgz \
+              --bucket caffeine-salt \
+              --key cdn/files/janus-bin/janus-latest-pr.tgz
+        when:
+          steps:
+            - name: CreateArtifacts
+              on:
+                - success
+      UploadMaster:
+        title: Upload master binary archive
+        description: |-
+          Upload master binary archive to S3
+        image: 'opsgang/awscli:stable'
+        environment:
+          - AWS_REGION=us-west-2
+        working_directory: /codefresh/volume
+        commands:
+          - |-
+            artifact=janus-master-${tag}-b${CF_BUILD_ID}.tgz
+            aws s3api put-object \
+              --acl bucket-owner-full-control \
+              --body janus.tgz \
+              --bucket caffeine-salt \
+              --key cdn/files/janus-bin/$artifact
+        when:
+          branch:
+            only:
+              - master
+          steps:
+            - name: CreateArtifacts
+              on:
+                - success
+      UploadLatestMaster:
+        title: Upload latest master binary archive
+        description: |-
+          Upload master binary archive to S3
+        image: 'opsgang/awscli:stable'
+        environment:
+          - AWS_REGION=us-west-2
+        working_directory: /codefresh/volume
+        commands:
+          - |-
+            aws s3api put-object \
+              --acl bucket-owner-full-control \
+              --body janus.tgz \
+              --bucket caffeine-salt \
+              --key cdn/files/janus-bin/janus-latest-master.tgz
+        when:
+          branch:
+            only:
+              - master
+          steps:
+            - name: CreateArtifacts
+              on:
+                - success
+
+

--- a/caffeine/codefresh.build.yaml
+++ b/caffeine/codefresh.build.yaml
@@ -58,6 +58,7 @@ steps:
         commands:
           - |-
             artifact=janus-pr${CF_PULL_REQUEST_NUMBER}-${tag}-b${CF_BUILD_ID}.tgz
+            echo "Uploading /caffeine-salt/janus-bin/$artifact"
             aws s3api put-object \
               --acl bucket-owner-full-control \
               --body janus.tgz \
@@ -78,6 +79,7 @@ steps:
         working_directory: /codefresh/volume
         commands:
           - |-
+            echo "Uploading /caffeine-salt/janus-bin/janus-latest-pr.tgz"
             aws s3api put-object \
               --acl bucket-owner-full-control \
               --body janus.tgz \
@@ -99,6 +101,7 @@ steps:
         commands:
           - |-
             artifact=janus-master-${tag}-b${CF_BUILD_ID}.tgz
+            echo "Uploading /caffeine-salt/janus-bin/$artifact"
             aws s3api put-object \
               --acl bucket-owner-full-control \
               --body janus.tgz \
@@ -122,6 +125,7 @@ steps:
         working_directory: /codefresh/volume
         commands:
           - |-
+            echo "Uploading /caffeine-salt/janus-bin/janus-latest-master.tgz"
             aws s3api put-object \
               --acl bucket-owner-full-control \
               --body janus.tgz \

--- a/caffeine/scripts/codefresh-build.sh
+++ b/caffeine/scripts/codefresh-build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+PREFIX=/opt/janus
+DEP_PRE=/usr/local/lib
+
+function prepare_directories {
+  mkdir -p $CF_VOLUME_PATH/$PREFIX/lib/
+}
+
+function copy_deps {
+  cp -P $DEP_PRE/libsrtp* $CF_VOLUME_PATH/$PREFIX/lib
+  cp -P $DEP_PRE/libnice* $CF_VOLUME_PATH/$PREFIX/lib
+  cp -P $DEP_PRE/libconfig* $CF_VOLUME_PATH/$PREFIX/lib
+}
+
+function build_janus {
+  echo "Building Janus"
+  sh autogen.sh
+  ./configure \
+    --prefix=$PREFIX \
+    --disable-data-channels \
+    --disable-docs \
+    --disable-mqtt \
+    --disable-plugin-audiobridge \
+    --disable-plugin-echotest \
+    --disable-plugin-recordplay \
+    --disable-plugin-sip \
+    --disable-plugin-textroom \
+    --disable-plugin-videocall \
+    --disable-plugin-voicemail \
+    --disable-post-processing \
+    --disable-rabbitmq \
+    --disable-turn-rest-api \
+    --disable-sample-event-handler \
+    --disable-websockets \
+    --enable-unix-sockets \
+    --enable-plugin-streaming \
+    --enable-plugin-videoroom \
+    --enable-rest \
+    --enable-static
+  make check install DESTDIR=$CF_VOLUME_PATH
+}
+
+# Just adding some skeleton code
+function main {
+  prepare_directories
+  copy_deps
+  build_janus
+}
+
+main


### PR DESCRIPTION
Adds a base Dockerfile which is used by codefresh to build Janus,
janus-plugin-forwarder, and create the artifacts bundle to be uploaded
to the S3 bucket.

NOTE: Unlike Jenkins, Codefresh does not provide an increasing build
number. Instead, it provides each build with a unique identifier. This
is used in place of the build number to tag build artifacts.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/janus-gateway/4)
<!-- Reviewable:end -->
